### PR TITLE
last-command-char no longer exists, use last-command-event instead.

### DIFF
--- a/caps-mode.el
+++ b/caps-mode.el
@@ -38,7 +38,7 @@
 (defun caps-mode-self-insert-command (&optional n)
   "Like `self-insert-command', but uppercase the the typed character."
   (interactive "p")
-  (insert-char (upcase last-command-char) n))
+  (insert-char (upcase last-command-event) n))
 
 (defvar caps-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
some things have changed since 2004...